### PR TITLE
Added info for Shippable.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Thanks to the contributors: [cmllr](https://github.com/cmllr), [Ibrahim-Islam](h
     - [**Codeship**](#codeship)
     - [**TeamCity**](#teamcity)
     - [**Travis CI (Org)**](#travis-ci-org)
+    - [**Shippable**](#shippable)
 - [User authentication](#user-authentication)
     - [**Auth0**](#auth0)
     - [**Firebase authentication**](#firebase-authentication)

--- a/README.md
+++ b/README.md
@@ -264,6 +264,15 @@ Thanks to the contributors: [cmllr](https://github.com/cmllr), [Ibrahim-Islam](h
 * *Pros*: great language and hosting provider support, integrates with many tools (GitHub, Bitbucket, Code Climate, Slack, Jira, etc)
 * *Limitations*: free tier is limited to open source projects
 
+### ** Shippable **
+
+[Home page](https://app.shippable.com/)
+
+* *Free tier*: unlimited projects from either public or private repos
+* *Pros*: integrates with Github or Bitbucket, uses Docker buildpacks, custom images, YAML file config, build badges, integrates with a whole tonne of stuff, including various Amazon services, Slack, Gitlab, IRC, Jenkins and JFrog Artifactory
+* *Cons*: Sometimes the service is a little shakey; I've had it go down a couple of times in the last month or so
+* *Limitations*: free tier limited to one build 'minion' and 150 builds per month for private repositories. Additional minions are $25 p/m with unlimited builds
+
 ## User authentication
 
 ### **Auth0**

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Thanks to the contributors: [cmllr](https://github.com/cmllr), [Ibrahim-Islam](h
 * *Pros*: great language and hosting provider support, integrates with many tools (GitHub, Bitbucket, Code Climate, Slack, Jira, etc)
 * *Limitations*: free tier is limited to open source projects
 
-### ** Shippable **
+### **Shippable**
 
 [Home page](https://app.shippable.com/)
 


### PR DESCRIPTION
Shippable is a CI product and a cheaper alternative to something like Travis CI. The main benefit on the free tier is that you can use it with either public or private repos (with some limitations in terms of build minutes/month for private repos).