### PR TITLE
Added Rollbar, corrected pricing for Sentry

### DIFF
--- a/pages/error-reporting.md
+++ b/pages/error-reporting.md
@@ -2,14 +2,22 @@
 
 <!-- TOC depthFrom:2 -->
 
+- [Rollbar](#rollbar)
 - [Sentry](#sentry)
 
 <!-- /TOC -->
+## Rollbar
+
+[Pricing page](https://rollbar.com/pricing/)
+
+* *Free tier*: 5,000 events/month, 30-day data history
+* *Pros*: Unlimited users, no mandatory rate limits, full-featured support for the most popular languages & frameworks, full API access, full access to Rollbar technical support
+* *Limitations*: SAML-based SSO (Okta, Google Apps, Bitium) only available in paid tiers
 
 ## Sentry
 
 [Pricing page](https://sentry.io/pricing/)
 
-* *Free tier*: 5000 events/day, 30-day history
+* *Free tier*: 5 events/minute, 30-day history
 * *Pros*: supports source maps, view source code in stack traces, request/session information available, filtering, API access, Single sign-on
-* *Limitations*: No pay-as-you-go model
+* *Limitations*: No pay-as-you-go model, 60-second rolling rate limit on free tier


### PR DESCRIPTION
Sentry's website claims 5,000 events/day, but limits are in fact enforced on a minute-by-minute basis, so this is a theoretical maximum for the amount of data that can be sent.