### PR TITLE
Added Rollbar to Error Reporting

### DIFF
--- a/pages/error-reporting.md
+++ b/pages/error-reporting.md
@@ -2,14 +2,22 @@
 
 <!-- TOC depthFrom:2 -->
 
+- [Rollbar](#rollbar)
 - [Sentry](#sentry)
 
 <!-- /TOC -->
+## Rollbar
+
+[Pricing page](https://rollbar.com/pricing/)
+
+* *Free tier*: 5,000 events/month, 30-day data history
+* *Pros*: Unlimited users, no mandatory rate limits, full-featured support for the most popular languages & frameworks, full API access, full access to Rollbar technical support
+* *Limitations*: SAML-based SSO (Okta, Google Apps, Bitium) only available in paid tiers
 
 ## Sentry
 
 [Pricing page](https://sentry.io/pricing/)
 
-* *Free tier*: 5000 events/day, 30-day history
+* *Free tier*: 5 events/minute, 30-day history
 * *Pros*: supports source maps, view source code in stack traces, request/session information available, filtering, API access, Single sign-on
-* *Limitations*: No pay-as-you-go model
+* *Limitations*: No pay-as-you-go model, 60-second rolling rate limit on free tier

--- a/pages/error-reporting.md
+++ b/pages/error-reporting.md
@@ -18,6 +18,6 @@
 
 [Pricing page](https://sentry.io/pricing/)
 
-* *Free tier*: 5 events/minute, 30-day history
+* *Free tier*: 10 events/minute, 30-day history
 * *Pros*: supports source maps, view source code in stack traces, request/session information available, filtering, API access, Single sign-on
 * *Limitations*: No pay-as-you-go model, 60-second rolling rate limit on free tier


### PR DESCRIPTION
Added entry for Rollbar, updated Sentry data to reflect rate limit of 10 events/minute on free tier