### PR TITLE
Update 'zeit now' limitations

### DIFF
--- a/pages/app-hosting.md
+++ b/pages/app-hosting.md
@@ -106,4 +106,4 @@ Scalable, high-performance virtual machines
 
 * *Free tier*: 1GB storage, 1GB bandwidth/month, 100MB logs/month, unlimited deploys/month, 3 concurrent instances
 * *Pros*: multi cloud, served over HTTP/2, use Node.js last version, can also host static websites
-* *Limitations*: maximum of 1MB per file, no custom domain, source code is always public
+* *Limitations*: maximum of 5MB per file, no custom domain, source code is always public


### PR DESCRIPTION
I was checking https://zeit.co/pricing and found that the maximum file size for the free tier is 5mb.

![image](https://user-images.githubusercontent.com/3900123/43084329-dac6dd80-8e6e-11e8-8e16-3dd079d1e54b.png)
