### PR TITLE
Add Dependabot under dependency management

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Some ads (sorry, self-promotion :smile:)
 <div style="display:flex;">
-    <div><h4 align="center"><a href="https://mockoon.com"><img src="https://mockoon.com/images/logo.svg" width="120" alt="Mockoon logo"><br>Mock APIs like a pro with this app I created</a></h4></div>    
+    <div><h4 align="center"><a href="https://mockoon.com"><img src="https://mockoon.com/images/logo.svg" width="120" alt="Mockoon logo"><br>Mock APIs like a pro with this app I created</a></h4></div>
 </div>
 
 # What is it?
@@ -93,6 +93,8 @@ Please also have a look to the [List of excluded services](pages/excluded-servic
     - [Redsmin](pages/database-management.md#redsmin)
 - [**Data mining**](pages/data-mining.md)
     - [Metabase](pages/data-mining.md#metabase)
+- [**Dependency management**](pages/dependency-management.md)
+    - [Dependbaot](pages/dependency-management.md#dependabot)
 - [**DNS hosting**](pages/dns-hosting.md)
     - [LuaDNS](pages/dns-hosting.md#luadns)
 - [**Emailing**](pages/emailing.md)

--- a/pages/dependency-management.md
+++ b/pages/dependency-management.md
@@ -1,0 +1,15 @@
+# Dependency management
+
+<!-- TOC depthFrom:2 -->
+
+- [Dependabot](#dependabot)
+
+<!-- /TOC -->
+
+## Dependabot
+
+[Pricing page](https://dependabot.com/)
+
+* *Free tier*: Unlimited private repos for personal GitHub accounts
+* *Pros*: Automatically creates dependency update PRs with links to changelogs etc.
+* *Exceeding the free tier*: Paid subscription needed for private repos hosted on a GitHub organisation account


### PR DESCRIPTION
I couldn't see an obvious section for [Dependabot](https://dependabot.com), so created a new "dependency management" section. Alternatively it could have gone under "security", but I would have had to have created that, too :octocat:.