### PR TITLE
remove github limitations paragraph on code collaboration tools page

### DIFF
--- a/pages/code-collaboration-tools.md
+++ b/pages/code-collaboration-tools.md
@@ -40,7 +40,6 @@
 
 * *Free tier*: unlimited public repositories with unlimited collaborators and organizations. Unlimited private repositories with up to 3 collaborators
 * *Pros*: provide issue tracking, code snippets (Gist), code reviews, wiki, organizations/team management, 3rd party integration and hooks, has a desktop app
-* *Limitations*: private repositories limited to 3 collaborators
 
 ## GitLab
 


### PR DESCRIPTION
Since April 14 Github allows to invite unlimited number of collaborators to private repos as stated [here](https://github.blog/changelog/2020-04-14-private-repositories-with-unlimited-collaborators-available-to-all-github-accounts-and-changes-to-github-paid-plans/), so I removed the limitation paragraph on code collaboration tools page :)