### PR TITLE
Add supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Please also have a look to the [List of excluded services](pages/excluded-servic
     - [MongoDB Atlas](pages/database-hosting.md#mongodb-atlas)
     - [Openshift MongoDB](pages/database-hosting.md#openshift-mongodb)
     - [Redis Cloud](pages/database-hosting.md#redis-cloud)
+    - [Supabase Postgres](pages/database-hosting.md#supabase)
 - [**Database management**](pages/database-management.md)
     - [Redsmin](pages/database-management.md#redsmin)
 - [**Data mining**](pages/data-mining.md)

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Please also have a look to the [List of excluded services](pages/excluded-servic
     - [MongoDB Atlas](pages/database-hosting.md#mongodb-atlas)
     - [Openshift MongoDB](pages/database-hosting.md#openshift-mongodb)
     - [Redis Cloud](pages/database-hosting.md#redis-cloud)
-    - [Supabase Postgres](pages/database-hosting.md#supabase)
+    - [Supabase Postgres](pages/database-hosting.md#supabase-postgres)
 - [**Database management**](pages/database-management.md)
     - [Redsmin](pages/database-management.md#redsmin)
 - [**Data mining**](pages/data-mining.md)

--- a/pages/database-hosting.md
+++ b/pages/database-hosting.md
@@ -119,3 +119,12 @@
 
 * *Free tier*: 30MB, 30 connections
 * *Pros*: managed, possibility to choose cloud provider (AWS, Azure, GCE, IBM Softlayer) and availability zones
+
+## Supabase Postgres
+
+[Pricing Page](https://supabase.io/pricing)
+
+* *Free tier*: 500Mb storage, 100 simultaneous connections
+* *Pros*: Open source, built in realtime capabilities and auth, 40+ extensions and pgbouncer preinstalled 
+* *Limitations*: Paused after 1 week of inactivity
+* *Exceeding the free tier*: There are no overage charges. Team will reach out asking user to upgrade to a higher plan if limits are exceeded. 

--- a/pages/database-hosting.md
+++ b/pages/database-hosting.md
@@ -15,6 +15,7 @@
 - [MongoDB Atlas](#mongodb-atlas)
 - [OpenShift MongoDB](#openshift-mongodb)
 - [Redis Cloud](#redis-cloud)
+- [Supabase Postgres](#supabase-postgres)
 
 <!-- /TOC -->
 


### PR DESCRIPTION
Adds [Supabase](https://supabase.io) to the list of database hosting providers 