### PR TITLE
Update error-reporting.md (Sentry)

### DIFF
--- a/pages/error-reporting.md
+++ b/pages/error-reporting.md
@@ -47,6 +47,6 @@
 
 [Pricing page](https://sentry.io/pricing/)
 
-* *Free tier*: 10,000 events/month, 30-day history
+* *Free tier*: 5,000 events/month, 30-day history
 * *Pros*: [BSD-licensed open source](https://github.com/getsentry/sentry), supports source maps and symbolication, view source code in stack traces, request/session information available, filtering, API access, Single sign-on
 * *Limitations*: Limit 1 user


### PR DESCRIPTION
Not sure if this changed, but it seems to be the limit for the free Sentry tier now https://sentry.io/pricing/