### PR TITLE
Add Operous.dev to Security Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ The goal is to have enough details about each free tier so developers can choose
 - [**Searching**](pages/searching.md)
     - [Algolia](pages/searching.md#algolia)
 - [**Security**](pages/security.md)
+    - [Operous](pages/security.md#operous)
     - [Snyk](pages/security.md#snyk)
 - [**Serverless app hosting**](pages/serverless-app-hosting.md)
     - [AWS Lambda](pages/serverless-app-hosting.md#aws-lambda)

--- a/pages/security.md
+++ b/pages/security.md
@@ -2,9 +2,17 @@
 
 <!-- TOC depthFrom:2 -->
 
+- [Operous](#operous)
 - [Snyk](#snyk)
 
 <!-- /TOC -->
+
+## Operous
+
+[Pricing page](https://operous.dev/#pricing)
+
+- *Free tier:* 1 User, up to 5 Instances, 100 testing minutes, and 10 Test Suites.
+- *Pros:* Help you understand configuration and security issues in your cloud instance.
 
 ## Snyk
 


### PR DESCRIPTION
Add the [Operous.dev](https://operous.dev) to security tools.