### PR TITLE
Add Ory user auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ The goal is to have enough details about each free tier so developers can choose
     - [LoginRadius](pages/user-authentication.md#loginradius)
     - [MojoAuth](pages/user-authentication.md#mojoauth)
     - [Okta](pages/user-authentication.md#okta)
+    - [Ory](pages/user-authentication.md#ory)
     - [Visual Studio Mobile Center](pages/user-authentication.md#visual-studio-mobile-center)
 - [**Web Scraping**](pages/web-scraping.md)
     - [Apify](pages/web-scraping.md#apify)

--- a/pages/user-authentication.md
+++ b/pages/user-authentication.md
@@ -9,6 +9,7 @@
 - [LoginRadius](#loginradius)
 - [MojoAuth](#mojoauth)
 - [Okta](#okta)
+- [Ory](#ory)
 - [Visual Studio Mobile Center](#visual-studio-mobile-center)
 
 <!-- /TOC -->
@@ -66,14 +67,16 @@
 - *Free tier*: Up to 7,000 monthly active users, Up to 10 custom apps, OAuth 2.0 & OpenID Connect.
 - *Pros*: Complete authentication, authorization and user management through their API, client libraries for multiple languages.
 
+## Ory
+
+[Pricing page](https://www.ory.sh/pricing/), [Open Source](https://www.ory.sh/docs/ecosystem/projects)
+
+* *Free tier*: always free, unlimited users, rate limit requests/minute
+* *Pros*: Open Source (Apache2), API first, support FIDO2/WebAuthn, SDKs for all languages, custom UI & flows cloud native
+
 ## Visual Studio Mobile Center
 
 [Pricing Page](https://docs.microsoft.com/en-us/mobile-center/general/pricing)
 
 * *Free tier*: 10 mobile apps and 500 active users while in preview
 * *Pros*: offers multiple login providers (Azure Active Directory, Microsoft Account, Facebook, Google, Twitter), client libraries for iOS, Android, Cordova, Windows, Xamarin.Android, Xamarin.iOS, Xamarin.Forms), UI support
-
-
-
-
-


### PR DESCRIPTION
This patch adds [Ory](https://www.ory.sh/) to user authentication solutions. 
we have a free tier on the managed solution and all services are also available to selfhost under apache2 license. Ory is used in production by huge and small companies, securing ~50B requests monthly. https://github.com/ory/kratos#who-is-using-it


- fix: add ory to user auth
- fix: add ory to README

