### PR TITLE
Remove PlanetScale from Database hosting, add Aiven MySQL/PostgreSQL/Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ The goal is to have enough details about each free tier so developers can choose
     - [Neon](pages/database-hosting.md#neon)
     - [Openshift MongoDB](pages/database-hosting.md#openshift-mongodb)
     - [Oracle Cloud](pages/database-hosting.md#oracle-cloud)
-    - [PlanetScale](pages/database-hosting.md#planetscale)
     - [Railway](pages/database-hosting.md#railway)
     - [Redis Cloud](pages/database-hosting.md#redis-cloud)
     - [Supabase Postgres](pages/database-hosting.md#supabase-postgres)

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The goal is to have enough details about each free tier so developers can choose
     - [Travis CI (Org)](pages/continuous-integration-delivery.md#travis-ci-org)
     - [Visual Studio Team Services](pages/continuous-integration-delivery.md#visual-studio-team-services)
 - [**Database hosting**](pages/database-hosting.md)
+    - [Aiven MySQL/PostgreSQL/Redis](pages/database-hosting.md#aiven)
     - [AWS DynamoDB](pages/database-hosting.md#aws-dynamodb)
     - [Cloud AMQP](pages/database-hosting.md#cloud-amqp)
     - [Cloudant CouchDB](pages/database-hosting.md#cloudant-couchdb)

--- a/pages/database-hosting.md
+++ b/pages/database-hosting.md
@@ -2,6 +2,7 @@
 
 <!-- TOC depthFrom:2 -->
 
+- [Aiven MySQL/PostgreSQL/Redis](#aiven)
 - [AWS DynamoDB](#aws-dynamodb)
 - [Cloudant CouchDB](#cloudant-couchdb)
 - [DataStax Astra Cassandra](#datastax-astra-cassandra)
@@ -21,6 +22,12 @@
 - [Supabase Postgres](#supabase-postgres)
 
 <!-- /TOC -->
+
+## aiven
+[Product page](https://aiven.io/free-mysql-database)
+* *Free tier*: 1 VM, 1 CPU, 1 GB RAm, 5 GB storage for PostgreSQL and MySQL, one free PostgreSQL, one free MySQL, and one free Redis
+* *Pros:* Dedicated VM, no credit card required, Performance graphs, Data encrypted on disk and network, Backups for disaster recovery, One-click version upgrade, certifications like SOC2, ISO27001, PCI-DSS and GDPR
+* *Limitations*: For PostgreSQL: no connection pooling, Support only through the Aiven Community Forum, Only a limited number of DigitalOcean regions, Not covered under Aiven's 99.99% SLA
 
 ## AWS DynamoDB
 

--- a/pages/database-hosting.md
+++ b/pages/database-hosting.md
@@ -127,13 +127,6 @@
 * *Pros*: Flexible workload tuning
 * *Limitations*: Maximum of 20 simultaneous database sessions
 
-## PlanetScale
-
-[Pricing Page](https://planetscale.com/pricing)
-
-* _Free tier_: 1 Database, 5Gb, 1 billion row read/month, 10 million row write/month, 1 production and 1 development branch
-* _Pros_: Serverless MySQL platform
-
 ## Railway
 
 [Pricing page](https://railway.app/pricing)


### PR DESCRIPTION
Planatscale has no free plan anymore: 
https://planetscale.com/blog/planetscale-forever

seems like aiven is a good option for free MySQL/PostgreSQL/Redis hosting