### PR TITLE
KS DB Merge Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The goal is to have enough details about each free tier so developers can choose
     - [Redis Cloud](pages/database-hosting.md#redis-cloud)
     - [Supabase Postgres](pages/database-hosting.md#supabase-postgres)
 - [**Database management**](pages/database-management.md)
-    - [KS DB Merge Tools](pages/database-management.md#ksdbmergetools)
+    - [KS DB Merge Tools](pages/database-management.md#ks-db-merge-tools)
     - [Redsmin](pages/database-management.md#redsmin)
 - [**Database modeling**](pages/database-modeling.md)
     - [ERD Lab](pages/database-modeling.md#erdlab)

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The goal is to have enough details about each free tier so developers can choose
     - [Redis Cloud](pages/database-hosting.md#redis-cloud)
     - [Supabase Postgres](pages/database-hosting.md#supabase-postgres)
 - [**Database management**](pages/database-management.md)
+    - [KS DB Merge Tools](pages/database-management.md#ksdbmergetools)
     - [Redsmin](pages/database-management.md#redsmin)
 - [**Database modeling**](pages/database-modeling.md)
     - [ERD Lab](pages/database-modeling.md#erdlab)

--- a/pages/database-management.md
+++ b/pages/database-management.md
@@ -2,7 +2,7 @@
 
 <!-- TOC depthFrom:2 -->
 
-- [KS DB Merge Tools](#ksdbmergetools)
+- [KS DB Merge Tools](#ks-db-merge-tools)
 - [Redsmin](#redsmin)
 
 <!-- /TOC -->

--- a/pages/database-management.md
+++ b/pages/database-management.md
@@ -2,10 +2,21 @@
 
 <!-- TOC depthFrom:2 -->
 
+- [KS DB Merge Tools](#ksdbmergetools)
 - [Redsmin](#redsmin)
 
 <!-- /TOC -->
 
+## KS DB Merge Tools
+
+[Product page](https://ksdbmerge.tools)
+
+* *Free tier*: GUI for Windows - basic database diff and merge tasks; schema - primary object types (in most cases it is tables, views, stored procedures and functions), data - per table comparison and syncronization. Command line - free to use on Linux (see Limitations).
+* *Pros*: Simple GUI to observe the primary database schema changes, easy way to get changed rows and counts for particular table. Command line on Linux allows to get some reports and sync scripts which are available only in the paid Standard version.
+* *Limitations*: GUI - Standard features are not available (schema - more object types, data - views, custom queries, batch data diff, etc.). Command line - license does not allow automated use of the free Linux version by companies and organizations
+* *Exceeding the free tier*: Not possible for GUI. Command line usage is not tracked and no actions are made in case if automated usage statement is violated.
+* *Credit card required:* no
+  
 ## Redsmin
 
 [Pricing page](https://www.redsmin.com/)

--- a/pages/database-management.md
+++ b/pages/database-management.md
@@ -3,7 +3,6 @@
 <!-- TOC depthFrom:2 -->
 
 - [Redsmin](#redsmin)
-- [ERDLab](#erdlab)
 
 <!-- /TOC -->
 
@@ -14,11 +13,3 @@
 * *Free tier*: Manage 1 redis instance
 * *Pros*: Full Redis server administration and monitoring, real-time monitoring and editing (including batch editing), unlimited alerting
 * *Exceeding the free tier*: Credit card needed after first 30 days to charge exceeding usage. Free downgrade possible through support.
-
-
-## ERDLab
-[Application page](https://app.erdlab.io/)
-
-* *Free tier*: 100% free for everyone
-* *Pros*: Cloud based ERD tool to draw your database diagrams. Import existing SQL or start from scratch and export SQL/PDF/Image when done. Supports MySQL, PostgreSQL, Oracle, MS SQL, SQLite, SnowFlake and more.
-* *Exceeding the free tier*: No limits on free tier. The application is free for everyone.


### PR DESCRIPTION
I wanted to reorder database-management.md before adding KS DB Merge to the top (according to CONTRIBUTING.md), but when I started to edit ToC in master.md I noticed that ERDLab is listed in separate pages/database-modeling.md#erdlab with almost the same content. So I removed copy from database-management.md.