### PR TITLE
Add AI Dev Jobs API to Misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ The goal is to have enough details about each free tier so developers can choose
     - [Google Cloud Pub/Sub](pages/messaging-queue-services.md#google-cloud-pubsub)
 - [**Misc**](pages/misc.md)
     - [APIVerve](pages/misc.md#apiverve)
+    - [AI Dev Jobs API](pages/misc.md#ai-dev-jobs-api)
     - [Argonaut](pages/misc.md#argonaut)
     - [ExchangeRate-API](pages/misc.md#exchangerate-api)
     - [FingerprintJS Pro](pages/misc.md#fingerprintjs-pro)

--- a/pages/misc.md
+++ b/pages/misc.md
@@ -3,6 +3,7 @@
 <!-- TOC depthFrom:2 -->
 
 - [APIVerve](#apiverve)
+- [AI Dev Jobs API](#ai-dev-jobs-api)
 - [Argonaut](#argonaut)
 - [ExchangeRate-API](#exchangerate-api)
 - [FingerprintJS Pro](#fingerprintjs-pro)
@@ -25,6 +26,15 @@
 - _Pros_: High quality curated APIs to help build your next project, 1 API Key gives you access to all APIs
 - _Limitations_: Free tier has rate limits, and some API features are locked down on the free tier
 - _Exceeding the free tier_: API calls return an error
+
+## AI Dev Jobs API
+
+[API docs](https://aidevboard.com/api-docs)
+
+- _Free Tier_: 100 API requests per hour, no authentication required
+- _Pros_: 7,400+ AI/ML job listings from 400+ companies, search by role, company, location, and salary. OpenAPI 3.0 spec available. Also offered as an MCP server for AI agents
+- _Limitations_: free tier limited to 100 requests per hour
+- _Exceeding the free tier_: API returns a rate limit error with Retry-After header
 
 ## Argonaut
 


### PR DESCRIPTION
Adds [AI Dev Jobs API](https://aidevboard.com/api-docs) to the Misc section.

AI Dev Jobs provides a free REST API for accessing AI/ML job listings data:

- **Free tier**: 100 API requests per hour, no authentication required
- **Data**: 7,400+ job listings from 400+ companies with salary information
- **Docs**: OpenAPI 3.0 spec at `/openapi.yaml`, full docs at `/api-docs`
- **Also available**: as an MCP server for AI agent integration

This fits the "data APIs" category mentioned in the contributing guidelines (alongside currency/geocoding APIs).

Changes:
- Added entry to `pages/misc.md` (alphabetically between APIVerve and Argonaut)
- Updated table of contents in `README.md`