### PR TITLE
Add IPASIS to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ The goal is to have enough details about each free tier so developers can choose
 - [**Searching**](pages/searching.md)
     - [Algolia](pages/searching.md#algolia)
 - [**Security**](pages/security.md)
+    - [IPASIS](pages/security.md#ipasis)
     - [Snyk](pages/security.md#snyk)
 - [**Serverless app hosting**](pages/serverless-app-hosting.md)
     - [Catalyst AppSail](pages/serverless-app-hosting.md#catalyst-appsail)  

--- a/pages/security.md
+++ b/pages/security.md
@@ -2,9 +2,20 @@
 
 <!-- TOC depthFrom:2 -->
 
+- [IPASIS](#ipasis)
 - [Snyk](#snyk)
 
 <!-- /TOC -->
+
+## IPASIS
+
+[Pricing page](https://ipasis.com/#pricing)
+
+- *Free tier*: 1,000 API requests/day for real-time bot detection, IP reputation scoring, VPN/proxy/Tor detection, and email validation. Single REST endpoint returns an Interaction Trust Score (0-100).
+- *Pros*: sub-20ms response time, combines IP intelligence and email risk in one call, simple JSON API with no SDK required, live scanner tool at ipasis.com/scan
+- *Limitations*: free tier limited to 1,000 requests/day
+- *Exceeding the free tier*: API returns a rate limit error; paid plans available for higher volumes
+- *Credit card required*: No
 
 ## Snyk
 
@@ -13,3 +24,4 @@
 - *Free tier:* 200 open source tests, 100 container tests, 300 IaC tests, 100 Snyk Code tests - all per month.
 - *Pros:* GitHub Pull Requests integration, IDE extensions, a CLI
 - *Limitations:* No license reports, JIRA integrations, API or rich reports
+


### PR DESCRIPTION
Adds [IPASIS](https://ipasis.com) to the Security section — a real-time bot detection and fraud prevention API with a generous free tier.

**Free tier details:**
- 1,000 API requests/day
- No credit card required
- Single REST endpoint for IP reputation, VPN/proxy/Tor detection, email validation, and bot scoring
- Sub-20ms response time

IPASIS fits the "stack on a budget" criteria well: the free tier is production-usable for small projects protecting signups, logins, or API endpoints from automated abuse.

Changes:
- `pages/security.md` — added IPASIS entry (alphabetical order, before Snyk)
- `README.md` — updated table of contents