### PR TITLE
Add host4.ai to App hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The goal is to have enough details about each free tier so developers can choose
     - [Glitch](pages/app-hosting.md#glitch)
     - [Google App Engine](pages/app-hosting.md#google-app-engine)
     - [Google Compute Engine](pages/app-hosting.md#google-compute-engine)
+    - [host4.ai](pages/app-hosting.md#host4ai)
     - [IBM Cloud](pages/app-hosting.md#ibm-cloud)
     - [Koyeb](pages/app-hosting.md#koyeb)
     - [Netlify](pages/app-hosting.md#netlify)

--- a/pages/app-hosting.md
+++ b/pages/app-hosting.md
@@ -10,6 +10,7 @@
 - [Glitch](#glitch)
 - [Google App Engine](#google-app-engine)
 - [Google Compute Engine](#google-compute-engine)
+- [host4.ai](#host4ai)
 - [IBM Cloud](#ibm-cloud)
 - [Koyeb](#koyeb)
 - [Netlify](#netlify)
@@ -87,6 +88,14 @@
 * *Pros*: Works well with other Google Cloud features (load balancing, datastores, etc.)
 * *Limitations*: Limited to US region only for now
 * *Credit card required*: Yes, you must provide a [credit card or other payment method](https://cloud.google.com/free/docs/free-cloud-features), even for a free trial
+
+## host4.ai
+
+[Pricing page](https://host4.ai/#pricing)
+
+* *Free tier*: 20 AI builder credits, SSH terminal access, free .host4.ai subdomain
+* *Pros*: Cloud hosting with AI coding agents (Claude Code, Codex) preinstalled, Describe what you want and AI builds and deploys it live, Browser-based terminal, No setup required
+* *Limitations*: Limited AI builder credits on free tier
 
 ## IBM Cloud
 


### PR DESCRIPTION
## Summary

- Adds [host4.ai](https://host4.ai) to the **App hosting** section
- Cloud hosting platform with AI coding agents (Claude Code, Codex) preinstalled — describe what you want and AI builds and deploys it live
- Free tier: 20 AI builder credits, SSH terminal access, free .host4.ai subdomain
- Entry added in alphabetical order to both `pages/app-hosting.md` and `README.md` TOC