### PR TITLE
Move Mailtrap to Emailing section and update free tier limits

### DIFF
--- a/pages/emailing.md
+++ b/pages/emailing.md
@@ -9,6 +9,7 @@
 - [SendGrid](#sendgrid)
 - [SparkPost](#sparkpost)
 - [Mailazy](#mailazy)
+- [Mailtrap](#mailtrap)
 
 <!-- /TOC -->
 
@@ -67,3 +68,11 @@
 * *Free tier*: 10000 emails/month, 350 emails/day sending limit, get upto 50,000 email/month in beta program
 * *Pros*: Integrate either with SMTP or REST Email API, real-time analytics and logs, No credit card required
 * *Exceeding the free tier*: sending stops, upgrade plan
+
+## Mailtrap
+
+[Pricing page](https://mailtrap.io/pricing/)
+
+* *Free tier*: 4,000 emails/month, 150 emails/day via Email API and SMTP. Email Marketing: 500 contacts, 1,500 emails/month. Email Sandbox: 50 test emails/month, 1 sandbox, 10 stored emails
+* *Pros*: Full Email API and SMTP sending platform with sandbox testing, delivery analytics, and contact management. No credit card required
+* *Exceeding the free tier*: Sending stops, upgrade plan required

--- a/pages/misc.md
+++ b/pages/misc.md
@@ -9,7 +9,6 @@
 - [Geocodio](#geocodio)
 - [ipapi.is](#ipapiis)
 - [Let's Encrypt](#lets-encrypt)
-- [Mailtrap](#mailtrap)
 - [ostr.io](#ostrio)
 - [QRMint](#qrmint)
 - [Svix](#svix)
@@ -76,15 +75,6 @@
 - _Free tier_: provide SSL certificates for free
 - _Pros_: free, support for wildcard certificates
 - _Limitations_: certificates are valid for 90 days so automation is strongly recommended
-
-## Mailtrap
-
-[Pricing page](https://mailtrap.io/pricing)
-
-- _Free tier_: 1 inbox, 50 messages per inbox, 2 emails/sec per inbox
-- _Pros_: Easy to setup
-- _Limitations_: No team members, no forward rules, no email address
-
 
 ## ostr.io
 


### PR DESCRIPTION
Mailtrap has evolved beyond a misc/testing tool into a full Email API and SMTP sending platform.

Changes:
1. Removed Mailtrap from the Misc section
2. Added Mailtrap to the Emailing section with accurate current free tier limits

Free tier details:
- Email API/SMTP: 4,000 emails/month, 150 emails/day
- Email Marketing: 500 contacts, 1,500 emails/month
- Email Sandbox: 50 test emails/month, 1 sandbox, 10 stored emails