### PR TITLE
Add SocialCrawl to Web Scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ The goal is to have enough details about each free tier so developers can choose
     - [PageShot](pages/web-scraping.md#pageshot)
     - [Scraper API](pages/web-scraping.md#scraper-api)
     - [SearchApi](pages/web-scraping.md#searchapi)
+    - [SocialCrawl](pages/web-scraping.md#socialcrawl)
     - [PhantomJsCloud](pages/web-scraping.md#phantomjscloud)
 - [**Website audit**](pages/website-audit.md)
     - [Checkbot](pages/website-audit.md#checkbot)

--- a/pages/web-scraping.md
+++ b/pages/web-scraping.md
@@ -8,6 +8,7 @@
 - [PageShot](#pageshot)
 - [Scraper API](#scraper-api)
 - [SearchApi](#searchapi)
+- [SocialCrawl](#socialcrawl)
 - [PhantomJsCloud](#phantomjscloud)
 
 <!-- /TOC -->
@@ -68,3 +69,13 @@
 * *Free tier*: About 500 pages/day ($0.05/day in credit)
 * *Pros*: Browser Automation, PDF Generation, Screenshots, Full request/response details in JSON.  Scales to hundreds of parallel requests.
 * *Limitations*: Free tier blocked from using the Builtin Anonymous Proxy system.
+
+## SocialCrawl
+
+[SocialCrawl pricing](https://www.socialcrawl.dev/pricing)
+
+* *Free tier*: 100 credits on signup; credits never expire. Standard endpoints cost 1 credit. Cache hits and failed requests are not charged.
+* *Pros*: One GET /v1 API and one JSON schema across 50+ social and commerce platforms. OpenAPI spec published at /v1/openapi.json.
+* *Limitations*: Free allotment is one-time, not monthly. Advanced/premium endpoints cost 5 or 10 credits; /v1/search/everywhere costs 20. 50 concurrent requests per key.
+* *Exceeding the free tier*: API returns 402 until more credits are purchased.
+* *Credit card required*: No


### PR DESCRIPTION
Adds SocialCrawl under Web Scraping and updates the table of contents.
Free tier: 100 credits on signup, never expire, no card required.
Exceeding: 402 until credits are purchased.
I work on SocialCrawl / Ridio.